### PR TITLE
英単語と日本語の登録コードをリファクタリング

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -32,34 +32,21 @@ class PostsController < ApplicationController
     @post = current_user.posts.build(post_params)
 
     if @post.title.present?
-      array_english = []
-      array_japanese = []
       10.times do |i|
-        #英語のパラメーターを取得
-        input_english = params[:english][i.to_s]
-        #スペースで区切った英語を配列に格納
-        array_english << input_english.split(/[[:space:]]/)
-        #日本語のパラメーターを取得
-        input_japanese = params[:japanese][i.to_s]
-        #スペースで区切った日本語を配列に格納
-        array_japanese << input_japanese.split(/[[:space:]]/)
-      end
-      i = 0
-      while i < 10
+        input_english = params[:english][i.to_s].split(/[[:space:]]/) if params[:english][i.to_s].present?
+        input_japanese = params[:japanese][i.to_s].split(/[[:space:]]/) if params[:japanese][i.to_s].present?
         #英語と日本語がともに存在し、かつ両方の要素が複数でなく、片方が複数である可能性を含む場合に処理を実行
-        if array_english[i].present? && array_japanese[i].present? && !(array_english[i].length >= 2 && array_japanese[i].length >= 2)
-          @post.save unless @post.persisted?
-          array_english[i].each do |en|
-            english_word = current_user.english_words.find_or_create_by(english: en, post_id: @post.id)
-            array_japanese[i].each do |jp|
-              japanese_word = current_user.japanese_words.find_or_create_by(japanese: jp, post_id: @post.id)
-              Word.find_or_create_by(english_word_id: english_word.id, japanese_word_id: japanese_word.id, post_id: @post.id)
-            end
+        if input_english.present? && input_japanese.present? && !(input_english.length >= 2 && input_japanese.length >= 2)
+         @post.save unless @post.persisted?
+         input_english.each do |en|
+           english_word = current_user.english_words.find_or_create_by(english: en, post_id: @post.id)
+           input_japanese.each do |jp|
+             japanese_word = current_user.japanese_words.find_or_create_by(japanese: jp, post_id: @post.id)
+             Word.find_or_create_by(english_word_id: english_word.id, japanese_word_id: japanese_word.id, post_id: @post.id)
+           end
           end
         end
-        i += 1
       end
-
       if @post.persisted?
         redirect_to @post, notice: t('posts.update.success') if @post.persisted?
       else#この処理は@post.titleは存在するが他がnilの場合

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,14 +1,21 @@
 <%= form_with(model: [post, english_word, japanese_word], url: posts_path, class: "contents") do |form| %>
 
   <div class="my-5">
-    <%= form.text_field :title, name: "post[title]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder: "タイトルを入力", required: true %>
+    <span class="text-red-500">*</span>
+    <%= form.text_field :title, name: "post[title]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 w-full", placeholder: "タイトルを入力", required: true %>
     <p class="mt-3">※単語の組み合わせを最低一つ入力してください</p>
     <p class="mt-3">※どちらがが複数の意味を持つ場合はスペースを使用して入力します(例: book ⇄ 本 予約する)</p>
     <% 10.times do |i| %>
     <div class="flex">
       <p><%= "#{i + 1}" %></p>
+      <% if i.zero? %>
+        <span class="text-red-500 mb-0">*</span>
+      <% end %>
       <%= form.text_field :english, name: "english[#{i}]",  class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder:"英語を入力", required: i.zero? %>
       <p>⇄</p>
+      <% if i.zero? %>
+        <span class="text-red-500 mb-0">*</span>
+      <% end %>
       <%= form.text_field :japanese, name: "japanese[#{i}]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder:"日本語を入力", required: i.zero? %>
       </div>
     <% end %>


### PR DESCRIPTION
### この修正の目的

- 英単語と日本語を登録する際の条件分岐が不要だったため
- またコードをより簡潔にするため
***
### やったこと
dfcdef31c844e82ec03a9064269d4cf9532c6026

1. 英語と日本語のパラメータをループ変数ごとに取得
2. それを英語と日本語の配列に代入
3. 作成した配列それぞれをeachで回し英語、日本語ともに作成、中間テーブルに保存
4. またタイトルが存在するが他がnilの場合はエラー
5. タイトルそもそも存在しない場合もエラー
***
### TODO

**バリデーションの作成**

- 英語のフィールドの入力値は英語だけにする
- 日本語のフィールドの入力値は日本語だけにする
