### PR TITLE
英単語と日本語の編集・更新機能の修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -48,7 +48,7 @@ class PostsController < ApplicationController
         end
       end
       if @post.persisted?
-        redirect_to @post, notice: t('posts.update.success') if @post.persisted?
+        redirect_to @post, notice: t('posts.create.success') if @post.persisted?
       else#この処理は@post.titleは存在するが他がnilの場合
         @post = Post.new
         @english_word = EnglishWord.new
@@ -72,54 +72,38 @@ class PostsController < ApplicationController
       @post.words.destroy_all
       @post.english_words.destroy_all
       @post.japanese_words.destroy_all
-      array_english = []
-      array_japanese = []
-      #20timesにした理由はedit.erbでeach_with_indexのループ変数がうまく渡せず飛んでしまうため仮の対処
-      20.times do |i|
-        #英語のパラメーターを取得
-        input_english = params[:english][i.to_s]
-        #スペースで区切った英語を配列に格納
-        array_english << input_english.split(/[[:space:]]/) if input_english.present?
-        #日本語のパラメーターを取得
-        input_japanese = params[:japanese][i.to_s]
-        #スペースで区切った日本語を配列に格納
-        array_japanese << input_japanese.split(/[[:space:]]/) if input_japanese.present?
-      end
-      array_english.zip(array_japanese).each do |english, japanese|
-        #両方nilだったら
-        next if english.empty? && japanese.empty?
-        #両方2つ以上の意味を持っていたら
-        next if english.length >= 2 && japanese.length >= 2
-        #英語がnilで日本語があったら
-        next if english.empty? && japanese.present?
-        #日本語がnilで英語があったら
-        next if japanese.empty? && english.present?
-        #英語が一つで日本語が2つ以上だったら
-        if english.length == 1 && japanese.length >= 2
-          @english_word = current_user.english_words.create(english: english[0], post_id: @post.id)
-          japanese.each do |word|
-            @japanese_word = current_user.japanese_words.create(japanese: word, post_id: @post.id)
-            @word = Word.create(english_word_id: @english_word.id, japanese_word_id: @japanese_word.id, post_id: @post.id)
+      if @post.title.present?
+        10.times do |i|
+          input_english = params[:english][i.to_s].split(/[[:space:]]/) if params[:english][i.to_s].present?
+          input_japanese = params[:japanese][i.to_s].split(/[[:space:]]/) if params[:japanese][i.to_s].present?
+          #英語と日本語がともに存在し、かつ両方の要素が複数でなく、片方が複数である可能性を含む場合に処理を実行
+          if input_english.present? && input_japanese.present? && !(input_english.length >= 2 && input_japanese.length >= 2)
+           @post.save unless @post.persisted?
+           input_english.each do |en|
+             english_word = current_user.english_words.find_or_create_by(english: en, post_id: @post.id)
+             input_japanese.each do |jp|
+               japanese_word = current_user.japanese_words.find_or_create_by(japanese: jp, post_id: @post.id)
+               Word.find_or_create_by(english_word_id: english_word.id, japanese_word_id: japanese_word.id, post_id: @post.id)
+             end
+            end
           end
-        #日本語が１つで英語が2つ以上だったら
-        elsif japanese.length == 1 && english.length >= 2
-          @japanese_word = current_user.japanese_words.create(japanese: japanese[0], post_id: @post.id)
-          english.each do |word|
-            @english_word = current_user.english_words.create(english: word, post_id: @post.id)
-            @word = Word.create(english_word_id: @english_word.id, japanese_word_id: @japanese_word.id, post_id: @post.id)
-          end
-        #英語が1つで日本語も１つだったら
-        else english.length == 1 && japanese.length == 1
-          @english_word = current_user.english_words.create(english: english[0], post_id: @post.id)
-          @japanese_word = current_user.japanese_words.create(japanese: japanese[0], post_id: @post.id)
-          @word = Word.create(english_word_id: @english_word.id, japanese_word_id: @japanese_word.id, post_id: @post.id)
         end
+        if @post.persisted?
+          redirect_to @post, notice: t('posts.update.success') if @post.persisted?
+        else#この処理は@post.titleは存在するが他がnilの場合
+          @post = Post.new
+          @english_word = EnglishWord.new
+          @japanese_word = JapaneseWord.new
+          flash.now[:alert] = t('posts.create.failure')
+          render :new, status: :unprocessable_entity
+        end
+      else
+        @post = Post.new
+        @english_word = EnglishWord.new
+        @japanese_word = JapaneseWord.new
+        flash.now[:alert] = t('posts.create.failure')
+        render :new, status: :unprocessable_entity
       end
-      redirect_to @post, notice: t('posts.update.success')
-    else
-      flash.now[:alert] = t('posts.update.failure')
-      render :edit, status: :unprocessable_entity
-    end
   end
 
   # DELETE /posts/1

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -67,43 +67,42 @@ class PostsController < ApplicationController
 
   # PATCH/PUT /posts/1
   def update
-    if @post.save
-      # 既存の単語をすべて削除
-      @post.words.destroy_all
-      @post.english_words.destroy_all
-      @post.japanese_words.destroy_all
-      if @post.title.present?
-        10.times do |i|
-          input_english = params[:english][i.to_s].split(/[[:space:]]/) if params[:english][i.to_s].present?
-          input_japanese = params[:japanese][i.to_s].split(/[[:space:]]/) if params[:japanese][i.to_s].present?
-          #英語と日本語がともに存在し、かつ両方の要素が複数でなく、片方が複数である可能性を含む場合に処理を実行
-          if input_english.present? && input_japanese.present? && !(input_english.length >= 2 && input_japanese.length >= 2)
-           @post.save unless @post.persisted?
-           input_english.each do |en|
-             english_word = current_user.english_words.find_or_create_by(english: en, post_id: @post.id)
-             input_japanese.each do |jp|
-               japanese_word = current_user.japanese_words.find_or_create_by(japanese: jp, post_id: @post.id)
-               Word.find_or_create_by(english_word_id: english_word.id, japanese_word_id: japanese_word.id, post_id: @post.id)
-             end
-            end
+    # 既存の単語をすべて削除
+    @post.words.destroy_all
+    @post.english_words.destroy_all
+    @post.japanese_words.destroy_all
+    if @post.title.present?
+      10.times do |i|
+        input_english = params[:english][i.to_s].split(/[[:space:]]/) if params[:english][i.to_s].present?
+        input_japanese = params[:japanese][i.to_s].split(/[[:space:]]/) if params[:japanese][i.to_s].present?
+        #英語と日本語がともに存在し、かつ両方の要素が複数でなく、片方が複数である可能性を含む場合に処理を実行
+        if input_english.present? && input_japanese.present? && !(input_english.length >= 2 && input_japanese.length >= 2)
+         @post.save unless @post.persisted?
+         input_english.each do |en|
+           english_word = current_user.english_words.find_or_create_by(english: en, post_id: @post.id)
+           input_japanese.each do |jp|
+             japanese_word = current_user.japanese_words.find_or_create_by(japanese: jp, post_id: @post.id)
+             Word.find_or_create_by(english_word_id: english_word.id, japanese_word_id: japanese_word.id, post_id: @post.id)
+           end
           end
         end
-        if @post.persisted?
-          redirect_to @post, notice: t('posts.update.success') if @post.persisted?
-        else#この処理は@post.titleは存在するが他がnilの場合
-          @post = Post.new
-          @english_word = EnglishWord.new
-          @japanese_word = JapaneseWord.new
-          flash.now[:alert] = t('posts.create.failure')
-          render :new, status: :unprocessable_entity
-        end
-      else
+      end
+      if @post.persisted?
+        redirect_to @post, notice: t('posts.update.success') if @post.persisted?
+      else#この処理は@post.titleは存在するが他がnilの場合
         @post = Post.new
         @english_word = EnglishWord.new
         @japanese_word = JapaneseWord.new
-        flash.now[:alert] = t('posts.create.failure')
+        flash.now[:alert] = t('posts.update.failure')
         render :new, status: :unprocessable_entity
       end
+    else
+      @post = Post.new
+      @english_word = EnglishWord.new
+      @japanese_word = JapaneseWord.new
+      flash.now[:alert] = t('posts.update.failure')
+      render :new, status: :unprocessable_entity
+    end
   end
 
   # DELETE /posts/1

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -8,39 +8,74 @@
       <p class="mt-3">※単語の組み合わせを最低一つ入力してください</p>
       <p class="mt-3">※どちらがが複数の意味を持つ場合はスペースを使用して入力します(例: book ⇄ 本 予約する)</p>
 
-      <% @words.each_with_index do |word, i| %>
-        <% if word.english_word.japanese_words.second.nil? && word.japanese_word.english_words.second.nil? %>
-          <div class="flex">
-            <% en_value = word.english_word.english %>
-            <% jp_value = word.japanese_word.japanese %>
-            <%= form.text_field :english, value: en_value, name: "english[#{i}]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder:"英語を入力" %>
-            <p>⇄</p>
-            <%= form.text_field :japanese, value: jp_value, name: "japanese[#{i}]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder:"日本語を入力" %>
-          </div>
+        <%  i = 0 %>
+        <% @words.each do |word| %>
+          <% if word.english_word.japanese_words.second.nil? && word.japanese_word.english_words.second.nil? %>
+            <div class="flex">
+              <p><%= "#{i + 1}" %></p>
+              <% en_value = word.english_word.english %>
+              <% jp_value = word.japanese_word.japanese %>
+              <% if i.zero? %>
+                <span class="text-red-500 mb-0">*</span>
+              <% end %>
+              <%= form.text_field :english, value: en_value, name: "english[#{i}]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder:"英語を入力", required: i.zero? %>
+              <p>⇄</p>
+              <% if i.zero? %>
+                <span class="text-red-500 mb-0">*</span>
+              <% end %>
+              <%= form.text_field :japanese, value: jp_value, name: "japanese[#{i}]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder:"日本語を入力", required: i.zero? %>
+            </div>
+            <% i += 1 %>
+          <% end %>
         <% end %>
-      <% end %>
-      <% @english_words.each_with_index do |en, i| %>
-        <% if en.japanese_words.second.present? %>
-          <div class="flex">
-            <% en_value = en.english %>
-            <% jp_values = en.japanese_words.map(&:japanese).join(' ') %>
-            <%= form.text_field :english, value: en_value, name: "english[#{i}]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder:"英語を入力" %>
-            <p>⇄</p>
-            <%= form.text_field :japanese, value: jp_values, name: "japanese[#{i}]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder:"日本語を入力" %>
-          </div>
+        <% @english_words.each do |en| %>
+          <% if en.japanese_words.second.present? %>
+            <div class="flex">
+              <p><%= "#{i + 1}" %></p>
+              <% en_value = en.english %>
+              <% jp_values = en.japanese_words.map(&:japanese).join(' ') %>
+              <% if i.zero? %>
+                <span class="text-red-500 mb-0">*</span>
+              <% end %>
+              <%= form.text_field :english, value: en_value, name: "english[#{i}]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder:"英語を入力", required: i.zero? %>
+              <p>⇄</p>
+              <% if i.zero? %>
+                <span class="text-red-500 mb-0">*</span>
+              <% end %>
+              <%= form.text_field :japanese, value: jp_values, name: "japanese[#{i}]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder:"日本語を入力", required: i.zero? %>
+            </div>
+            <% i += 1 %>
+          <% end %>
         <% end %>
-      <% end %>
-      <% @japanese_words.each_with_index do |jp, i| %>
-        <% if jp.english_words.second.present? %>
-          <div class="flex">
-            <% en_values = jp.english_words.map(&:english).join(' ') %>
-            <% jp_value = jp.japanese %>
-            <%= form.text_field :english, value: en_values, name: "english[#{i}]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder:"英語を入力" %>
-            <p>⇄</p>
-            <%= form.text_field :japanese, value: jp_value, name: "japanese[#{i}]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder:"日本語を入力" %>
-          </div>
+        <% @japanese_words.each do |jp| %>
+          <% if jp.english_words.second.present? %>
+            <div class="flex">
+              <p><%= "#{i + 1}" %></p>
+              <% en_values = jp.english_words.map(&:english).join(' ') %>
+              <% jp_value = jp.japanese %>
+              <% if i.zero? %>
+                <span class="text-red-500 mb-0">*</span>
+              <% end %>
+              <%= form.text_field :english, value: en_values, name: "english[#{i}]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder:"英語を入力" %>
+              <p>⇄</p>
+              <% if i.zero? %>
+                <span class="text-red-500 mb-0">*</span>
+              <% end %>
+              <%= form.text_field :japanese, value: jp_value, name: "japanese[#{i}]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder:"日本語を入力" %>
+            </div>
+            <% i += 1 %>
+          <% end %>
         <% end %>
-      <% end %>
+
+        <% while i < 10 do %>
+          <div class="flex">
+            <p><%= "#{i + 1}" %></p>
+            <%= form.text_field :english, name: "english[#{i}]",  class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder:"英語を入力" %>
+            <P>⇄</p>
+            <%= form.text_field :japanese, name: "japanese[#{i}]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder:"日本語を入力" %>
+          </div>
+          <% i += 1 %>
+        <% end %>
     </div>
 
     <div class="inline">


### PR DESCRIPTION
### この修正の目的

- 英語と日本語の編集のためのedit.html.erbの修正
- それに伴うコントローラの修正

***
### やったこと

**view側**

- each_with_indexを排除してi=0を定義して数字を0から９まで回せるようにした
- また入力フォームが英単語と日本語の組み合わせの数しか表示されていなかったので、１０個入力フォームが表示されるように修正した

**コントローラ側**

- each_with_indexを排除したのでcreate同様10.timesで配列を取得できうようになった

***

### TODO

- プラスボタンを設置して入力フォームを増減すること
- create同様、日本語は日本語,英語は英語だけ入力できるようにバリデーション