### PR TITLE
bookmark機能

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,0 +1,29 @@
+class BookmarksController < ApplicationController
+  before_action :set_post
+
+  def create
+    Bookmark.create(user_id: current_user.id, post_id: @post.id)
+
+    render turbo_stream: turbo_stream.replace(
+      'bookmark',
+      partial: 'bookmarks/bookmark',
+      locals: { post: @post },
+    )
+  end
+
+  def destroy
+    bookmark = Bookmark.find_by(user_id: current_user.id, post_id: @post.id)
+    bookmark.destroy
+
+    render turbo_stream: turbo_stream.replace(
+      'bookmark',
+      partial: 'bookmarks/bookmark',
+      locals: { post: @post },
+    )
+  end
+  
+  private
+  def set_post
+    @post = Post.find(params[:post_id])
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -115,6 +115,10 @@ class PostsController < ApplicationController
     @my_posts = Post.where(user_id: current_user.id)
   end
 
+  def bookmarks
+    @bookmark_posts = current_user.bookmark_posts
+  end
+
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_post

--- a/app/helpers/bookmarks_helper.rb
+++ b/app/helpers/bookmarks_helper.rb
@@ -1,0 +1,2 @@
+module BookmarksHelper
+end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,0 +1,6 @@
+class Bookmark < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+
+  validates :user_id, uniqueness: { scope: :post_id }
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,6 +3,11 @@ class Post < ApplicationRecord
   has_many :words, dependent: :destroy
   has_many :english_words, dependent: :destroy
   has_many :japanese_words, dependent: :destroy
+  has_many :bookmarks, dependent: :destroy
   
   validates :title, presence: true
+
+  def bookmarked_by?(user)
+    bookmarks.where(user_id: user).exists?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,11 @@ class User < ApplicationRecord
   has_many :japanese_words
   has_many :english_words
   has_many :posts
+  has_many :bookmarks, dependent: :destroy
+  #user.bookmarks.map(&:post)と同義
+  has_many :bookmark_posts, through: :bookmarks, source: :post
+  
+  def bookmark?(post)
+    bookmark_posts.include?(post)
+  end
 end

--- a/app/views/bookmarks/_bookmark.html.erb
+++ b/app/views/bookmarks/_bookmark.html.erb
@@ -1,0 +1,13 @@
+<turbo-frame id="bookmark">
+  <% if current_user.bookmark?(post) %>
+    <%= button_to post_bookmarks_path(post), method: :delete do %>
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 fill-blue-500">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M3 3l1.664 1.664M21 21l-1.5-1.5m-5.485-1.242L12 17.25 4.5 21V8.742m.164-4.078a2.15 2.15 0 011.743-1.342 48.507 48.507 0 0111.186 0c1.1.128 1.907 1.077 1.907 2.185V19.5M4.664 4.664L19.5 19.5" /></svg>
+    <% end %>
+  <% else %>
+    <%= button_to post_bookmarks_path(post), method: :post do %>
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0111.186 0z" /></svg>
+    <% end %>
+  <% end %>
+</turbo-flame>

--- a/app/views/posts/bookmarks.html.erb
+++ b/app/views/posts/bookmarks.html.erb
@@ -1,0 +1,6 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl my-4"><%= t('defaults.bookmarks') %></h1>
+   <div class="grid grid-cols-2 gap-4">
+     <%= render 'posts', posts: @bookmark_posts %>
+   </div>
+</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,5 +1,10 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-xl"><%= @post.title %></h1>
+  <div class="flex">
+    <h1 class="font-bold text-xl flex-1"><%= @post.title %></h1>
+    <div class="flex-1 flex flex-row-reverse">
+      <%= render 'bookmarks/bookmark', post: @post %>
+    </div>
+  </div>
   <div class="overflow-x-auto">
     <table class="table w-full">
       <!-- head -->

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -16,7 +16,7 @@
       <ul tabindex="0" class="mt-3 p-2 shadow menu menu-compact dropdown-content bg-base-100 rounded-box w-52">
         <li><%= button_to t('defaults.logout'), :logout, method: :post %></li>
         <li><%= link_to t('defaults.profile'), profile_path %></li>
-        <li><a>お気に入り</a></li>
+        <li><%= link_to t('defaults.bookmarks'), bookmarks_posts_path %></li>
         <li><%= link_to t('defaults.my-posts'), my_posts_path %></li>
         <li><%= link_to t('defaults.index'), posts_path(@posts) %>
         <li><a>LINE連携</a></li>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -10,6 +10,7 @@ ja:
     my-posts: あなたの英単語リスト
     new: 英単語作成
     edit: 編集
+    bookmarks: ブックマークリスト
   users:
     new:
       title: 新規登録

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,10 @@
 Rails.application.routes.draw do
-  resources :posts
+  resources :posts do
+    resource :bookmarks, only: %i[create destroy]
+    collection do
+      get :bookmarks
+    end
+  end
   get '/my_posts', to: 'posts#my_posts'
   get 'login' => 'user_sessions#new', :as => :login
   post 'login' => "user_sessions#create"

--- a/db/migrate/20230409144618_create_bookmarks.rb
+++ b/db/migrate/20230409144618_create_bookmarks.rb
@@ -1,0 +1,10 @@
+class CreateBookmarks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :bookmarks do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_30_103858) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_09_144618) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,21 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_30_103858) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "bookmarks", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_bookmarks_on_post_id"
+    t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  end
+
+  create_table "categories", force: :cascade do |t|
+    t.string "category", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "english_words", force: :cascade do |t|
@@ -93,6 +108,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_30_103858) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "bookmarks", "posts"
+  add_foreign_key "bookmarks", "users"
   add_foreign_key "english_words", "posts"
   add_foreign_key "english_words", "users"
   add_foreign_key "japanese_words", "posts"

--- a/spec/factories/bookmarks.rb
+++ b/spec/factories/bookmarks.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :bookmark do
+    user { nil }
+    post { nil }
+  end
+end

--- a/spec/helpers/bookmarks_helper_spec.rb
+++ b/spec/helpers/bookmarks_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the BookmarksHelper. For example:
+#
+# describe BookmarksHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe BookmarksHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Bookmark, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/bookmarks_spec.rb
+++ b/spec/requests/bookmarks_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Bookmarks", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
### この修正の目的

- 投稿をbookmark処理できるようにすること
- またbookmark処理の際は非同期で行うこと

***
### やったこと

**view側**

- userがbookmarkしたpostを持っているか持っていないかでcreate.destoryの処理を分けた。（_bookmark.html.erbのdoで囲んだところはアイコン)
- またturbo_streamで非同期処理を行うためにコントローラに渡すid=bookmarkを付与)

**コントローラ側**

- カレントユーザーが取得したpostを作成,削除することができる
- またturbo_streamで.replaceでviewからidを取得し作成,削除の切り替えを行える