### PR TITLE
投稿ジャンル機能

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -30,7 +30,6 @@ class PostsController < ApplicationController
   # POST /posts
   def create
     @post = current_user.posts.build(post_params)
-
     if @post.title.present?
       10.times do |i|
         input_english = params[:english][i.to_s].split(/[[:space:]]/) if params[:english][i.to_s].present?
@@ -77,7 +76,7 @@ class PostsController < ApplicationController
         input_japanese = params[:japanese][i.to_s].split(/[[:space:]]/) if params[:japanese][i.to_s].present?
         #英語と日本語がともに存在し、かつ両方の要素が複数でなく、片方が複数である可能性を含む場合に処理を実行
         if input_english.present? && input_japanese.present? && !(input_english.length >= 2 && input_japanese.length >= 2)
-         @post.save unless @post.persisted?
+         @post.update(post_params) unless @post.changed?
          input_english.each do |en|
            english_word = current_user.english_words.find_or_create_by(english: en, post_id: @post.id)
            input_japanese.each do |jp|
@@ -127,7 +126,7 @@ class PostsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def post_params
-      params.require(:post).permit(:title, :user_id)
+      params.require(:post).permit(:title, :user_id, :genre_id)
     end
 
     def english_word_params

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,0 +1,3 @@
+class Genre < ApplicationRecord
+  has_many :posts
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,6 @@
 class Post < ApplicationRecord
   belongs_to :user
+  belongs_to :genre
   has_many :words, dependent: :destroy
   has_many :english_words, dependent: :destroy
   has_many :japanese_words, dependent: :destroy

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -2,7 +2,11 @@
 
   <div class="my-5">
     <span class="text-red-500">*</span>
-    <%= form.text_field :title, name: "post[title]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 w-full", placeholder: "タイトルを入力", required: true %>
+    <div class="flex">
+      <%= form.text_field :title, name: "post[title]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 w-2/3", placeholder: "タイトルを入力", required: true %>
+      <%= form.collection_select :genre_id, Genre.all, :id, :name, { include_blank: "ジャンルを選択してください" }, { name: "post[genre_id]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 w-1/3" } %>
+    </div>
+    <p class="mt-3">※タイトルとジャンルを必ず入力・選択してください</p>
     <p class="mt-3">※単語の組み合わせを最低一つ入力してください</p>
     <p class="mt-3">※どちらがが複数の意味を持つ場合はスペースを使用して入力します(例: book ⇄ 本 予約する)</p>
     <% 10.times do |i| %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -4,7 +4,12 @@
   <%= form_with(model:  [@post, @english_words, @japanese_words, @words], url: post_path(@post), method: :patch, class: "contents") do |form| %>
 
     <div class="my-5">
-      <%= form.text_field :title, value: @post.title, name: "post[title]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder: "タイトルを入力", required: true %>
+      <span class="text-red-500">*</span>
+      <div class="flex">
+        <%= form.text_field :title, value: @post.title, name: "post[title]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 w-2/3", placeholder: "タイトルを入力", required: true %>
+        <%= form.collection_select :genre_id, Genre.all, :id, :name, { selected: @post.genre_id }, { name: "post[genre_id]", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 w-1/3"} %>
+      </div>
+      <p class="mt-3">※タイトルとジャンルを必ず入力・選択してください</p>
       <p class="mt-3">※単語の組み合わせを最低一つ入力してください</p>
       <p class="mt-3">※どちらがが複数の意味を持つ場合はスペースを使用して入力します(例: book ⇄ 本 予約する)</p>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -10,7 +10,7 @@
       <!-- head -->
       <thead>
         <tr>
-          <th></th>
+          <th><%= @post.genre.name %></th>
           <th>英語</th>
           <th>日本語</th>
           <th>覚えた?</th>

--- a/db/migrate/20230414110611_create_genres.rb
+++ b/db/migrate/20230414110611_create_genres.rb
@@ -1,0 +1,10 @@
+class CreateGenres < ActiveRecord::Migration[7.0]
+  def change
+    create_table :genres do |t|
+      t.string :name
+
+      t.timestamps
+    end
+    add_index :genres, :name, unique: true
+  end
+end

--- a/db/migrate/20230414113159_add_genre_to_posts.rb
+++ b/db/migrate/20230414113159_add_genre_to_posts.rb
@@ -1,0 +1,5 @@
+class AddGenreToPosts < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :posts, :genre, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_09_144618) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_14_113159) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -67,6 +67,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_09_144618) do
     t.index ["user_id"], name: "index_english_words_on_user_id"
   end
 
+  create_table "genres", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_genres_on_name", unique: true
+  end
+
   create_table "japanese_words", force: :cascade do |t|
     t.string "japanese"
     t.bigint "user_id", null: false
@@ -82,6 +89,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_09_144618) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "genre_id", null: false
+    t.index ["genre_id"], name: "index_posts_on_genre_id"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
@@ -114,6 +123,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_09_144618) do
   add_foreign_key "english_words", "users"
   add_foreign_key "japanese_words", "posts"
   add_foreign_key "japanese_words", "users"
+  add_foreign_key "posts", "genres"
   add_foreign_key "posts", "users"
   add_foreign_key "words", "english_words"
   add_foreign_key "words", "japanese_words"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,48 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+# db/seeds.rb
+
+# ジャンルのデータを配列で定義
+genres_data = [
+  { name: '名詞' },
+  { name: '代名詞' },
+  { name: '動詞' },
+  { name: '助動詞' },
+  { name: '形容詞' },
+  { name: '副詞' },
+  { name: '前置詞' },
+  { name: '接続詞' },
+  { name: '冠詞' },
+  { name: '間投詞' },
+  { name: 'TOEIC' },
+  { name: '英検' },
+  { name: '日常生活' },
+  { name: '生物(動物・植物など)' },
+  { name: '食品・飲み物' },
+  { name: '色' },
+  { name: '数字・日付' },
+  { name: '家族・人間関係' },
+  { name: '服装・ファッション' },
+  { name: '旅行' },
+  { name: 'スポーツ・運動' },
+  { name: '趣味・娯楽' },
+  { name: '職業・ビジネス' },
+  { name: '学業・教育' },
+  { name: '自然・環境' },
+  { name: '文化・芸術' },
+  { name: '音楽・映画・メディア' },
+  { name: '文学・歴史' },
+  { name: '宗教・哲学' },
+  { name: 'コンピュータ・IT' },
+  { name: '健康・美容' },
+  { name: '社会問題・政治' },
+  { name: '社交・イベント' },
+  { name: '住まい・家具' },
+  { name: 'スキル・能力' },
+  { name: 'SNS' },
+  { name: 'その他' },
+]
+
+# ジャンルレコードを作成
+Genre.create!(genres_data)

--- a/spec/factories/genres.rb
+++ b/spec/factories/genres.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :genre do
+    name { "MyString" }
+  end
+end

--- a/spec/models/genre_spec.rb
+++ b/spec/models/genre_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Genre, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
### この修正の目的

- 英単語の投稿を投稿する際にジャンルごとに振り分けられるようにした

***
### やったこと

- genreモデルを別で作りそこにジャンルを保存した
- ジャンルはseed.rbに記載することによってジャンルの追加、削除をしやすいようにした
- またpostがgenre_idを持てるようにしcollection_selectでジャンルをプルダウン形式で選択できるようにした
- 編集画面の際にはselectedで@post.genre_idを選択することによって保存データが表示される