### PR TITLE
cssが崩れていたので修正、ページネーション機能の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'ransack'
 gem 'line-bot-api'
 gem 'dotenv-rails'
 gem 'whenever', require: false
+gem 'kaminari'
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.4", ">= 7.0.4.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,18 @@ GEM
     jaro_winkler (1.5.4)
     json (2.6.3)
     jwt (2.7.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -357,6 +369,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   importmap-rails
+  kaminari
   line-bot-api
   pg (~> 1.1)
   pry-nav

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,7 @@ class PostsController < ApplicationController
 
   # GET /posts
   def index
-    @posts = @q.result.order(created_at: :desc)
+    @posts = @q.result.order(created_at: :desc).page(params[:page])
   end
 
   # GET /posts/1
@@ -110,17 +110,17 @@ class PostsController < ApplicationController
   end
 
   def my_posts
-    @my_posts = @q.result.where(user_id: current_user.id).order(created_at: :desc)
+    @my_posts = @q.result.where(user_id: current_user.id).order(created_at: :desc).page(params[:page])
   end
 
   def bookmarks
     @q = current_user.bookmark_posts.ransack(params[:q])
-    @bookmark_posts = @q.result.order(created_at: :desc)
+    @bookmark_posts = @q.result.order(created_at: :desc).page(params[:page])
   end
 
   def line_relations
     @q = current_user.line_relations.ransack(params[:q])
-    @line_relations = @q.result.order(created_at: :desc)
+    @line_relations = @q.result.order(created_at: :desc).page(params[:page])
   end
 
   def set_time

--- a/app/views/posts/_posts.html.erb
+++ b/app/views/posts/_posts.html.erb
@@ -1,18 +1,18 @@
 <% posts.each do |post| %>
   <%= link_to post_path(post) do %>
-    <div class= "card w-96 bg-base-300 text-neutral-content">
+    <div class= "card w-full bg-base-300 text-neutral-content">
       <div class="card-body">
         <h2 class="card-title"><%= post.title %></h2>
-        <div class="flex">
-          <div class="w-10 rounded-full ring overflow-hidden">
+          <div class="w-10 h-10 rounded-full ring overflow-hidden">
             <% if post.user.image.present? %>
-              <%= image_tag post.user.image, class: 'object-contain h-full w-full' %>
+              <%= image_tag post.user.image, class: 'object-cover w-full h-full rounded-full' %>
             <% else %>
-              <%= image_tag 'profile.png', class: 'object-contain h-full w-full' %>
+              <%= image_tag 'profile.png', class: 'object-cover w-full h-full rounded-full' %>
             <% end %>
-          </div>
-          <p class="mx-4"><%= created(post) %></p>
-          <p class="mx-4"><%= post.genre.name %></p>
+        </div>
+        <div class="flex">
+            <p class="mx-4"><%= created(post) %></p>
+            <p class="mx-4"><%= post.genre.name %></p>
         </div>
       </div>
     </div>

--- a/app/views/posts/bookmarks.html.erb
+++ b/app/views/posts/bookmarks.html.erb
@@ -5,7 +5,7 @@
       <%= render 'shared/search', q: @q, url: bookmarks_posts_path %>
     </div>
   </div>
-   <div class="grid grid-cols-2 gap-4">
+   <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
      <%= render 'posts', posts: @bookmark_posts %>
    </div>
 </div>

--- a/app/views/posts/bookmarks.html.erb
+++ b/app/views/posts/bookmarks.html.erb
@@ -1,4 +1,4 @@
-<div class="mx-auto md:w-2/3 w-full">
+<div class="mx-auto md:w-4/5 w-full">
   <div class="flex my-5">  
     <h1 class="font-bold text-4xl"><%= t('defaults.bookmarks') %></h1>
     <div class="ml-auto">
@@ -8,4 +8,5 @@
    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
      <%= render 'posts', posts: @bookmark_posts %>
    </div>
+   <%= paginate @bookmark_posts %>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,4 +1,4 @@
-<div class="mx-auto md:w-2/3 w-full">
+<div class="mx-auto md:w-4/5 w-full">
   <div class="flex my-5">
     <h1 class="font-bold text-4xl"><%= t('defaults.index') %></h1>
     <div class="ml-auto">
@@ -6,7 +6,7 @@
     </div>
   </div>
   
-  <div class="grid grid-cols-2 gap-4">
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
     <%= render 'posts', posts: @posts %>
   </div>
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -9,5 +9,5 @@
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
     <%= render 'posts', posts: @posts %>
   </div>
-
+  <%= paginate @posts %>
 </div>

--- a/app/views/posts/line_relations.html.erb
+++ b/app/views/posts/line_relations.html.erb
@@ -1,4 +1,4 @@
-<div class="mx-auto md:w-2/3 w-full">
+<div class="mx-auto md:w-4/5 w-full">
   <div class="flex my-5">  
     <h1 class="font-bold text-4xl"><%= t('defaults.line_relations') %></h1>
     <div class="ml-auto">
@@ -8,4 +8,5 @@
    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
      <%= render 'posts', posts: @line_relations  %>
    </div>
+   <%= paginate @line_relations %>
 </div>

--- a/app/views/posts/line_relations.html.erb
+++ b/app/views/posts/line_relations.html.erb
@@ -5,7 +5,7 @@
       <%= render 'shared/search', q: @q, url: line_relations_posts_path %>
     </div>
   </div>
-   <div class="grid grid-cols-2 gap-4">
+   <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
      <%= render 'posts', posts: @line_relations  %>
    </div>
 </div>

--- a/app/views/posts/my_posts.html.erb
+++ b/app/views/posts/my_posts.html.erb
@@ -1,4 +1,4 @@
-<div class="mx-auto md:w-2/3 w-full">
+<div class="mx-auto md:w-4/5 w-full">
   <div class="flex my-5">
     <h1 class="font-bold text-4xl"><%= t('defaults.my-posts') %></h1>
     <div class="ml-auto">
@@ -8,4 +8,5 @@
   <div class="grid grid-cols-2 gap-4">
     <%= render 'posts', posts: @my_posts %>
   </div>
+  <%= paginate @my_posts %>
 </div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 20
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -36,7 +36,7 @@ User.all.each do |user|
     if line_post.set_time.present?
       every 1.day, at: line_post.set_time.strftime("%I:%M %p") do
         runner "LineBot::LineMessage.send_message"
-      end
+      end  
     end
   end
 end


### PR DESCRIPTION
### この修正の目的

- デバイスのサイズによっては一覧画面がかなりくずれてしまうので修正した
- ページネーション機能を追加した

***
### やったこと

5d57fb8faec9cf3848cc57ed5dbc28b8d251e681

- タブレット以下のサイズでは一覧画面のレコードが１つずつ表示,それ以上は２つずつ表示
- 横幅を4/5にしてレイアウトが崩れないようにした

03f1f5da31cfc539b357077d50b1d9ebebb2514c

- gem kaminariを導入して２０レコードずつページネーションできるようにした

***

### TODO

- ページネーションのcssは何もいじってないので本格的にcssを整える時に一緒にデザインを考える